### PR TITLE
feat: add charm_kubernetes_label

### DIFF
--- a/src/charmed_service_mesh_helpers/__init__.py
+++ b/src/charmed_service_mesh_helpers/__init__.py
@@ -1,1 +1,5 @@
 """Helpers for the Service Mesh charms."""
+
+from .labels import charm_kubernetes_label
+
+__all__ = [charm_kubernetes_label]

--- a/src/charmed_service_mesh_helpers/labels.py
+++ b/src/charmed_service_mesh_helpers/labels.py
@@ -1,0 +1,64 @@
+"""Helpers for generating and managing Kubernetes labels."""
+
+import hashlib
+
+def charm_kubernetes_label(model_name: str, app_name: str, suffix: str = None) -> str:
+    """
+    Generate a Kubernetes label string in the form "{model_name}-{app_name}-{suffix}".
+
+    If the label exceeds 63 characters, truncate model_name and app_name, and append a hash of model_name-app_name to the end
+    ensure uniqueness. The hash is only included if truncation occurs.
+
+    Args:
+        model_name (str): The name of the model (must be at least 1 character).
+        app_name (str): The name of the application (must be at least 1 character).
+        suffix (str, optional): An optional suffix to append.  If omitted, there will be no trailing "-" on the label
+
+    Returns:
+        str: The generated label string, at most 63 characters long.
+
+    Raises:
+        ValueError: If model_name or app_name is empty, or if the fixed label portion is too long.
+    """
+    if not model_name or not app_name:
+        raise ValueError("Both model_name and app_name must be at least 1 character long.")
+
+    if suffix:
+        label = f"{model_name}-{app_name}-{suffix}"
+        base = label
+    else:
+        label = f"{model_name}-{app_name}"
+        base = label
+
+    max_length = 63
+    if len(label) <= max_length:
+        return label
+
+    # Generate a short hash for uniqueness
+    hash_digest = hashlib.sha1(base.encode()).hexdigest()[:6]
+    # Reserve space for hash and dashes
+    if suffix:
+        fixed_length = len(suffix) + len(hash_digest) + 3  # 3 dashes
+    else:
+        fixed_length = len(hash_digest) + 2  # 2 dashes
+
+    # Leave at least 1 character for each of truncated_model and truncated_app
+    min_variable_length = 2
+    if fixed_length + min_variable_length > max_length:
+        raise ValueError(
+            f"Fixed label portion (dashes, suffix, hash) is too long ({fixed_length} chars); "
+            f"must leave at least 1 character each for model_name and app_name to fit within "
+            f"the 63 character limit."
+        )
+
+    available = max_length - fixed_length
+    total = len(model_name) + len(app_name)
+    model_len = max(1, int(available * len(model_name) / total))
+    app_len = max(1, available - model_len)
+    truncated_model = model_name[:model_len]
+    truncated_app = app_name[:app_len]
+
+    if suffix:
+        return f"{truncated_model}-{truncated_app}-{suffix}-{hash_digest}"
+    else:
+        return f"{truncated_model}-{truncated_app}-{hash_digest}"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,74 @@
+import pytest
+from charmed_service_mesh_helpers import charm_kubernetes_label
+
+
+@pytest.mark.parametrize(
+    "model_name, app_name, suffix, expected",
+    [
+        ("model", "app", None, "model-app"),
+        ("model", "app", "svc", "model-app-svc"),
+        # Not truncated
+        (
+            "m" * 31,
+            "a" * 31,
+            None,
+            f"{'m'*31}-{'a'*31}",
+        ),
+        # Needs truncation
+        (
+            "m" * 32,
+            "a" * 31,
+            None,
+            f"mmmmmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaaaaaa-6014d8",
+        ),
+        # Needs truncation
+        (
+                "m" * 33,
+                "a" * 31,
+                None,
+                f"mmmmmmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaaaaa-928fe5",
+        ),
+        # Needs truncation with suffix
+        (
+            "m" * 40,
+            "a" * 40,
+            "suffix",
+            "mmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaa-suffix-cce1b8",
+        ),
+    ],
+)
+def test_generate_label_cases(model_name, app_name, suffix, expected):
+    if suffix is not None:
+        label = charm_kubernetes_label(model_name, app_name, suffix)
+    else:
+        label = charm_kubernetes_label(model_name, app_name)
+    assert label == expected
+    assert len(label) <= 63
+
+
+def test_truncated_labels_are_unique():
+    # These would truncate to the same prefix, but should have different hashes
+    label1 = charm_kubernetes_label("m" * 100, "a" * 100)
+    label2 = charm_kubernetes_label("m" * 90, "a" * 90)
+    assert label1 != label2
+    assert len(label1) <= 63
+    assert len(label2) <= 63
+
+
+def test_error_on_empty_model_or_app():
+    with pytest.raises(ValueError):
+        charm_kubernetes_label("", "app")
+    with pytest.raises(ValueError):
+        charm_kubernetes_label("model", "")
+
+
+@pytest.mark.parametrize(
+    "model_name, app_name, suffix",
+    [
+        ("m", "a", "s" * 60),           # Suffix so long that only 1 char left for model/app
+        ("m" * 60, "a", "s" * 53),      # Suffix + hash so long that only 1 char left for model/app
+    ],
+)
+def test_error_on_fixed_length_too_long_cases(model_name, app_name, suffix):
+    with pytest.raises(ValueError):
+        charm_kubernetes_label(model_name, app_name, suffix)

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,5 +1,0 @@
-"""A test placeholder just for getting the CI to work properly."""
-
-def test_passes():
-    """A placeholder test that always passes."""
-    assert True


### PR DESCRIPTION
Add function for generating a string including model_name and app_name that are suitable for a Kubernetes label.
