### PR TITLE
feat: add charm_kubernetes_label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "charmed-service-mesh-helpers"
 version = "999.999.999"  # Do not edit - automatically replaced with a valid release version at release time
 description = "Helpers for the Service Mesh charms."
 readme = "README.md"
-license = {"text" = "Apache-2.0" }
+license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ name = "charmed-service-mesh-helpers"
 version = "999.999.999"  # Do not edit - automatically replaced with a valid release version at release time
 description = "Helpers for the Service Mesh charms."
 readme = "README.md"
-license = "Apache-2.0"
-license-files = ["LICENSE"]
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 # Build system and project setup
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "charmed-service-mesh-helpers"
 version = "999.999.999"  # Do not edit - automatically replaced with a valid release version at release time
 description = "Helpers for the Service Mesh charms."
 readme = "README.md"
-license = "Apache-2.0"
+license.keys = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ name = "charmed-service-mesh-helpers"
 version = "999.999.999"  # Do not edit - automatically replaced with a valid release version at release time
 description = "Helpers for the Service Mesh charms."
 readme = "README.md"
-license.keys = "Apache-2.0"
-license-files = ["LICENSE"]
+license = {"text" = "Apache-2.0" }
+#license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Helpers for the Service Mesh charms."
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "999.999.999"  # Do not edit - automatically replaced with a valid rel
 description = "Helpers for the Service Mesh charms."
 readme = "README.md"
 license = {"text" = "Apache-2.0" }
-#license-files = ["LICENSE"]
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 # Build system and project setup
 [build-system]
-requires = ["setuptools>=77.0.3"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/src/charmed_service_mesh_helpers/__init__.py
+++ b/src/charmed_service_mesh_helpers/__init__.py
@@ -1,1 +1,5 @@
 """Helpers for the Service Mesh charms."""
+
+from .labels import charm_kubernetes_label
+
+__all__ = ['charm_kubernetes_label']

--- a/src/charmed_service_mesh_helpers/labels.py
+++ b/src/charmed_service_mesh_helpers/labels.py
@@ -8,8 +8,8 @@ def charm_kubernetes_label(
         app_name: str,
         prefix: str="",
         suffix: str="",
-        max_length=63,
-        separator="."
+        max_length: int=63,
+        separator: str="."
 ) -> str:
     """Generate a Kubernetes label string in the form "{prefix}{model_name}{separator}{app_name}{suffix}".
 

--- a/src/charmed_service_mesh_helpers/labels.py
+++ b/src/charmed_service_mesh_helpers/labels.py
@@ -1,0 +1,65 @@
+"""Helpers for generating and managing Kubernetes labels."""
+
+import hashlib
+from typing import Optional
+
+
+def charm_kubernetes_label(model_name: str, app_name: str, suffix: Optional[str] = None) -> str:
+    """Generate a Kubernetes label string in the form "{model_name}-{app_name}-{suffix}".
+
+    If the label exceeds 63 characters, truncate model_name and app_name, and append a hash of model_name-app_name to the end
+    ensure uniqueness. The hash is only included if truncation occurs.
+
+    Args:
+        model_name (str): The name of the model (must be at least 1 character).
+        app_name (str): The name of the application (must be at least 1 character).
+        suffix (str, optional): An optional suffix to append.  If omitted, there will be no trailing "-" on the label
+
+    Returns:
+        str: The generated label string, at most 63 characters long.
+
+    Raises:
+        ValueError: If model_name or app_name is empty, or if the fixed label portion is too long.
+    """
+    if not model_name or not app_name:
+        raise ValueError("Both model_name and app_name must be at least 1 character long.")
+
+    if suffix:
+        label = f"{model_name}-{app_name}-{suffix}"
+        base = label
+    else:
+        label = f"{model_name}-{app_name}"
+        base = label
+
+    max_length = 63
+    if len(label) <= max_length:
+        return label
+
+    # Generate a short hash for uniqueness
+    hash_digest = hashlib.sha1(base.encode()).hexdigest()[:6]
+    # Reserve space for hash and dashes
+    if suffix:
+        fixed_length = len(suffix) + len(hash_digest) + 3  # 3 dashes
+    else:
+        fixed_length = len(hash_digest) + 2  # 2 dashes
+
+    # Leave at least 1 character for each of truncated_model and truncated_app
+    min_variable_length = 2
+    if fixed_length + min_variable_length > max_length:
+        raise ValueError(
+            f"Fixed label portion (dashes, suffix, hash) is too long ({fixed_length} chars); "
+            f"must leave at least 1 character each for model_name and app_name to fit within "
+            f"the 63 character limit."
+        )
+
+    available = max_length - fixed_length
+    total = len(model_name) + len(app_name)
+    model_len = max(1, int(available * len(model_name) / total))
+    app_len = max(1, available - model_len)
+    truncated_model = model_name[:model_len]
+    truncated_app = app_name[:app_len]
+
+    if suffix:
+        return f"{truncated_model}-{truncated_app}-{suffix}-{hash_digest}"
+    else:
+        return f"{truncated_model}-{truncated_app}-{hash_digest}"

--- a/src/charmed_service_mesh_helpers/labels.py
+++ b/src/charmed_service_mesh_helpers/labels.py
@@ -1,20 +1,29 @@
 """Helpers for generating and managing Kubernetes labels."""
 
 import hashlib
-from typing import Optional
 
 
-def charm_kubernetes_label(model_name: str, app_name: str, prefix: str="", suffix: str="") -> str:
-    """Generate a Kubernetes label string in the form "{prefix}{model_name}-{app_name}{suffix}".
+def charm_kubernetes_label(
+        model_name: str,
+        app_name: str,
+        prefix: str="",
+        suffix: str="",
+        max_length=63,
+        separator="."
+) -> str:
+    """Generate a Kubernetes label string in the form "{prefix}{model_name}{separator}{app_name}{suffix}".
 
-    If the label exceeds 63 characters, truncate model_name and app_name, and append a hash of model_name-app_name to the end
-    ensure uniqueness. The hash is only included if truncation occurs.
+    If the label exceeds 63 characters, model_name and app_name will be truncated and a hash of
+    "{model_name}{separator}{app_name}" will be appended to the label to ensure uniqueness. The hash is only included if
+     truncation occurs.
 
     Args:
         model_name (str): The name of the model (must be at least 1 character).
         app_name (str): The name of the application (must be at least 1 character).
         prefix (str, optional): An optional prefix to prepend.
         suffix (str, optional): An optional suffix to append.
+        max_length (int, optional): The maximum length of the label string (default is 63).
+        separator (str, optional): The separator between model_name and app_name (default is ".").
 
     Returns:
         str: The generated label string, at most 63 characters long.
@@ -22,14 +31,13 @@ def charm_kubernetes_label(model_name: str, app_name: str, prefix: str="", suffi
     Raises:
         ValueError: If model_name or app_name is empty, or if the fixed label portion is too long.
     """
-    max_length = 63
     hash_length = 6
     min_characters_per_truncatable_part = 1
 
     if not model_name or not app_name:
         raise ValueError("Both model_name and app_name must be at least 1 character long.")
 
-    label = f"{prefix}{model_name}.{app_name}{suffix}"
+    label = f"{prefix}{model_name}{separator}{app_name}{suffix}"
     if len(label) <= max_length:
         return label
 
@@ -43,7 +51,7 @@ def charm_kubernetes_label(model_name: str, app_name: str, prefix: str="", suffi
         )
 
     # Generate a short hash for uniqueness
-    hash_digest = hashlib.sha1(f"{model_name}.{app_name}".encode()).hexdigest()[:hash_length]
+    hash_digest = hashlib.sha1(f"{model_name}{separator}{app_name}".encode()).hexdigest()[:hash_length]
 
     available = max_length - fixed_length
     total = len(model_name) + len(app_name)
@@ -52,4 +60,4 @@ def charm_kubernetes_label(model_name: str, app_name: str, prefix: str="", suffi
     truncated_model = model_name[:model_len]
     truncated_app = app_name[:app_len]
 
-    return f"{prefix}{truncated_model}.{truncated_app}.{hash_digest}{suffix}"
+    return f"{prefix}{truncated_model}{separator}{truncated_app}{separator}{hash_digest}{suffix}"

--- a/src/charmed_service_mesh_helpers/labels.py
+++ b/src/charmed_service_mesh_helpers/labels.py
@@ -3,45 +3,39 @@
 import hashlib
 
 
-def charm_kubernetes_label(
-        model_name: str,
-        app_name: str,
-        prefix: str="",
-        suffix: str="",
-        max_length: int=63,
-        separator: str="."
+def _truncate_charm_kubernetes_label(
+    model_name: str,
+    app_name: str,
+    prefix: str = "",
+    suffix: str = "",
+    max_length: int = 63,
+    separator: str = ".",
+    hash_length: int = 6,
+    min_characters_per_truncatable_part: int = 1,
 ) -> str:
-    """Generate a Kubernetes label string in the form "{prefix}{model_name}{separator}{app_name}{suffix}".
+    """Generate a Kubernetes label string in the form "{prefix}{model_name}{separator}{app_name}{suffix}{separator}{hash}".
 
-    If the label exceeds 63 characters, model_name and app_name will be truncated and a hash of
-    "{model_name}{separator}{app_name}" will be appended to the label to ensure uniqueness. The hash is only included if
-     truncation occurs.
+    The return will have model_name and app_name truncated in order for the string to be <=63 characters.  prefix and
+    suffix will not be truncated.  The hash is a hash of the entire, un-truncated `{model_name}{separator}{app_name}`
+    string which is included to ensure uniqueness when truncation occurs.
 
     Args:
-        model_name (str): The name of the model (must be at least 1 character).
-        app_name (str): The name of the application (must be at least 1 character).
-        prefix (str, optional): An optional prefix to prepend.
-        suffix (str, optional): An optional suffix to append.
-        max_length (int, optional): The maximum length of the label string (default is 63).
-        separator (str, optional): The separator between model_name and app_name (default is ".").
+        model_name: The name of the model (must be at least 1 character).
+        app_name: The name of the application (must be at least 1 character).
+        prefix: An optional prefix to prepend.
+        suffix: An optional suffix to append.
+        max_length: The maximum length of the label string.
+        separator: The separator between model_name and app_name.
+        hash_length: The length of the hash to append.
+        min_characters_per_truncatable_part: The minimum number of characters to keep for model_name
 
     Returns:
         str: The generated label string, at most 63 characters long.
 
     Raises:
-        ValueError: If model_name or app_name is empty, or if the fixed label portion is too long.
+        ValueError: If the fixed label portion is too long to allow for truncation.
     """
-    hash_length = 6
-    min_characters_per_truncatable_part = 1
-
-    if not model_name or not app_name:
-        raise ValueError("Both model_name and app_name must be at least 1 character long.")
-
-    label = f"{prefix}{model_name}{separator}{app_name}{suffix}"
-    if len(label) <= max_length:
-        return label
-
-    # If the un-truncated parts are too long, raise an error
+    # Validate whether the fixed length portions are short enough to succeed
     fixed_length = len(prefix) + len(suffix) + hash_length + 2  # 2 for the separators between model, app, and hash
     if fixed_length + 2 * min_characters_per_truncatable_part > max_length:
         raise ValueError(
@@ -53,6 +47,7 @@ def charm_kubernetes_label(
     # Generate a short hash for uniqueness
     hash_digest = hashlib.sha1(f"{model_name}{separator}{app_name}".encode()).hexdigest()[:hash_length]
 
+    # Truncate
     available = max_length - fixed_length
     total = len(model_name) + len(app_name)
     model_len = max(min_characters_per_truncatable_part, int(available * len(model_name) / total))
@@ -61,3 +56,57 @@ def charm_kubernetes_label(
     truncated_app = app_name[:app_len]
 
     return f"{prefix}{truncated_model}{separator}{truncated_app}{separator}{hash_digest}{suffix}"
+
+
+def charm_kubernetes_label(
+    model_name: str,
+    app_name: str,
+    prefix: str="",
+    suffix: str="",
+    max_length: int=63,
+    separator: str=".",
+) -> str:
+    """Generate a Kubernetes label string in the form "{prefix}{model_name}{separator}{app_name}{suffix}".
+
+    If the label exceeds 63 characters, model_name and app_name will be truncated and a hash of
+    "{model_name}{separator}{app_name}" will be appended to the label to ensure uniqueness. The hash is only included if
+    truncation occurs.
+
+    Further information about Kubernetes label restrictions can be found here:
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+
+    Note that the schema defines a label in the form:
+        prefix/name: value
+    where only the name and value must be <= 63 characters long. The prefix is not included in the 63 characters or
+    restricted in length.
+
+    Args:
+        model_name: The name of the model (must be at least 1 character).
+        app_name: The name of the application (must be at least 1 character).
+        prefix: An optional prefix to prepend.
+        suffix: An optional suffix to append.
+        max_length: The maximum length of the label string.
+        separator: The separator between model_name and app_name.
+
+    Returns:
+        str: The generated label string, at most 63 characters long.
+
+    Raises:
+        ValueError: If model_name or app_name is empty, or if the fixed label portion is too long.
+    """
+    if not model_name or not app_name:
+        raise ValueError("Both model_name and app_name must be at least 1 character long.")
+
+    label = f"{prefix}{model_name}{separator}{app_name}{suffix}"
+
+    if len(label) > max_length:
+        return _truncate_charm_kubernetes_label(
+            model_name=model_name,
+            app_name=app_name,
+            prefix=prefix,
+            suffix=suffix,
+            max_length=max_length,
+            separator=separator,
+        )
+
+    return label

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,75 @@
+import pytest
+
+from charmed_service_mesh_helpers import charm_kubernetes_label
+
+
+@pytest.mark.parametrize(
+    "model_name, app_name, suffix, expected",
+    [
+        ("model", "app", None, "model-app"),
+        ("model", "app", "svc", "model-app-svc"),
+        # Not truncated
+        (
+            "m" * 31,
+            "a" * 31,
+            None,
+            f"{'m'*31}-{'a'*31}",
+        ),
+        # Needs truncation
+        (
+            "m" * 32,
+            "a" * 31,
+            None,
+            "mmmmmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaaaaaa-6014d8",
+        ),
+        # Needs truncation
+        (
+                "m" * 33,
+                "a" * 31,
+                None,
+                "mmmmmmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaaaaa-928fe5",
+        ),
+        # Needs truncation with suffix
+        (
+            "m" * 40,
+            "a" * 40,
+            "suffix",
+            "mmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaa-suffix-cce1b8",
+        ),
+    ],
+)
+def test_generate_label_cases(model_name, app_name, suffix, expected):
+    if suffix is not None:
+        label = charm_kubernetes_label(model_name, app_name, suffix)
+    else:
+        label = charm_kubernetes_label(model_name, app_name)
+    assert label == expected
+    assert len(label) <= 63
+
+
+def test_truncated_labels_are_unique():
+    # These would truncate to the same prefix, but should have different hashes
+    label1 = charm_kubernetes_label("m" * 100, "a" * 100)
+    label2 = charm_kubernetes_label("m" * 90, "a" * 90)
+    assert label1 != label2
+    assert len(label1) <= 63
+    assert len(label2) <= 63
+
+
+def test_error_on_empty_model_or_app():
+    with pytest.raises(ValueError):
+        charm_kubernetes_label("", "app")
+    with pytest.raises(ValueError):
+        charm_kubernetes_label("model", "")
+
+
+@pytest.mark.parametrize(
+    "model_name, app_name, suffix",
+    [
+        ("m", "a", "s" * 60),           # Suffix so long that only 1 char left for model/app
+        ("m" * 60, "a", "s" * 53),      # Suffix + hash so long that only 1 char left for model/app
+    ],
+)
+def test_error_on_fixed_length_too_long_cases(model_name, app_name, suffix):
+    with pytest.raises(ValueError):
+        charm_kubernetes_label(model_name, app_name, suffix)

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -51,8 +51,8 @@ def test_generate_label_cases(model_name, app_name, prefix, suffix, expected):
 
 
 def test_separator():
-    label = charm_kubernetes_label("m"*40, "app"*40, "separator")
-    assert label == ""
+    label = charm_kubernetes_label("m"*40, "a"*40, separator="-")
+    assert label == "mmmmmmmmmmmmmmmmmmmmmmmmmmm-aaaaaaaaaaaaaaaaaaaaaaaaaaaa-ba9440"
     assert len(label) <= 63
 
 

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,5 +1,0 @@
-"""A test placeholder just for getting the CI to work properly."""
-
-def test_passes():
-    """A placeholder test that always passes."""
-    assert True


### PR DESCRIPTION
Add function for generating a string including model_name and app_name that are suitable for a Kubernetes label.