### PR TITLE
feat: adds namespaces and notNamespaces to istio source clause

### DIFF
--- a/src/charmed_service_mesh_helpers/models.py
+++ b/src/charmed_service_mesh_helpers/models.py
@@ -70,6 +70,8 @@ class Source(BaseModel):
 
     principals: Optional[List[str]] = None
     notPrincipals: Optional[List[str]] = None  # noqa: N815
+    namespaces: Optional[List[str]] = None
+    notNamespaces: Optional[List[str]] = None
     # Did not model everything.
 
 

--- a/src/charmed_service_mesh_helpers/models.py
+++ b/src/charmed_service_mesh_helpers/models.py
@@ -71,7 +71,7 @@ class Source(BaseModel):
     principals: Optional[List[str]] = None
     notPrincipals: Optional[List[str]] = None  # noqa: N815
     namespaces: Optional[List[str]] = None
-    notNamespaces: Optional[List[str]] = None
+    notNamespaces: Optional[List[str]] = None  # noqa: N815
     # Did not model everything.
 
 


### PR DESCRIPTION
## Issue
To support [this](https://github.com/canonical/istio-beacon-k8s-operator/pull/141#discussion_r2602177836), ie to be able to say "all sources from this namespace" can talk to a target, we need to use a different source type - `namespaces`. the current istio `Source` model does not support anything else other than principals. this PR extends the source model to allow namespace source types