### PR TITLE
feat: extends Source model with ip block entries

### DIFF
--- a/src/charmed_service_mesh_helpers/models.py
+++ b/src/charmed_service_mesh_helpers/models.py
@@ -70,7 +70,8 @@ class Source(BaseModel):
 
     principals: Optional[List[str]] = None
     notPrincipals: Optional[List[str]] = None  # noqa: N815
-    # Did not model everything.
+    ipBlocks: Optional[List[str]] = None  # noqa: N815
+    notIpBlocks: Optional[List[str]] = None  # noqa: N815
 
 
 class From(BaseModel):


### PR DESCRIPTION
Tandem for fixing https://github.com/canonical/istio-k8s-operator/issues/101

Adds `ipBlocks` source types in the `Source` model to let the `istio-ingress-k8s` create authz policies to target the gateway from specific CIDR blocks
